### PR TITLE
Extend documentation to include details of how arbitary values may be…

### DIFF
--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -21,6 +21,7 @@
 
       {{nav.section "Custom Modals"}}
       {{nav.item "With Form" "docs.modals.with-form"}}
+      {{nav.item "Passing Values" "docs.modals.passing-values"}}
     </viewer.nav>
 
     <viewer.main>

--- a/tests/dummy/app/templates/docs/modals/passing-values.md
+++ b/tests/dummy/app/templates/docs/modals/passing-values.md
@@ -1,0 +1,34 @@
+# Passing Values to Custom Components
+
+Modals making use of Custom Components may pass values to those components by assigning a value to a property of the object passed as an argument when invoking the modal. In the example below
+
+ 
+{{#docs-snippet name="show-alert-modal.js" title="Alert Modal"}}
+import Controller from '@ember/controller';
+import {inject as service} from '@ember/service';
+import {action, get} from '@ember/object';
+
+export default class AlertModalDemoController extends Controller {
+  @service()
+  modalsManager;
+
+  @action
+  showAlert() {
+    get(this, 'modalsManager')
+      .alert({bodyComponent: 'my-custom-body-component', username: 'Jane Doe'})
+      .then(() => {
+        // called after user clicks "Yes" in the modal
+      });
+  }
+}
+{{/docs-snippet}}
+
+Inside the template for the custom component `my-custom-body-component` the value of the `username` may be accessed in the usual way.
+
+{{#docs-snippet name="my-custom-body-component.hbs" title="My Custom Body Component Template"}}
+<div>
+The users name is : {{@username}}
+</div>
+{{/docs-snippet}}
+
+Clearly care needs to be taken that the properties used for passing values do not reuse the standard property names used by `ember-bootstrap-modals-manager`. 


### PR DESCRIPTION
_… passed to the custom components used by custom modals_

This is only a change to the addon documentation, the processing is unaffected.

This change was motivated by an [answer I received on StackOverflow](https://stackoverflow.com/questions/60346921/passing-values-to-ember-js-components-when-they-are-passed-as-an-argument-to-add). I would be interested if you felt the way I have presented the information was consistent with other parts of the documentation and any other feedback you might like to give. Thanks.