### PR TITLE
Remove broken component classes.

### DIFF
--- a/addon/components/modals-container/alert.js
+++ b/addon/components/modals-container/alert.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import AlertModal from 'ember-modals-manager-internal/components/modals-container/alert';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/alert';
-
-export default
-@templateLayout(layout)
-class _AlertModal extends AlertModal {
-}

--- a/addon/components/modals-container/base.js
+++ b/addon/components/modals-container/base.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import BaseModal from 'ember-modals-manager-internal/components/modals-container/base';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/base';
-
-export default
-@templateLayout(layout)
-class _BaseModal extends BaseModal {
-}

--- a/addon/components/modals-container/check-confirm.js
+++ b/addon/components/modals-container/check-confirm.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import CheckConfirmModal from 'ember-modals-manager-internal/components/modals-container/check-confirm';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/check-confirm';
-
-export default
-@templateLayout(layout)
-class _CheckConfirmModal extends CheckConfirmModal {
-}

--- a/addon/components/modals-container/confirm.js
+++ b/addon/components/modals-container/confirm.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import ConfirmModal from 'ember-modals-manager-internal/components/modals-container/confirm';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/confirm';
-
-export default
-@templateLayout(layout)
-class _ConfirmModal extends ConfirmModal {
-}

--- a/addon/components/modals-container/process.js
+++ b/addon/components/modals-container/process.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import ProcessModal from 'ember-modals-manager-internal/components/modals-container/process';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/process';
-
-export default
-@templateLayout(layout)
-class _ProcessModal extends ProcessModal {
-}

--- a/addon/components/modals-container/progress.js
+++ b/addon/components/modals-container/progress.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import ProgressModal from 'ember-modals-manager-internal/components/modals-container/progress';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/progress';
-
-export default
-@templateLayout(layout)
-class _ProgressModal extends ProgressModal {
-}

--- a/addon/components/modals-container/prompt-confirm.js
+++ b/addon/components/modals-container/prompt-confirm.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import PromptConfirmModal from 'ember-modals-manager-internal/components/modals-container/prompt-confirm';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/prompt-confirm';
-
-export default
-@templateLayout(layout)
-class _PromptConfirmModal extends PromptConfirmModal {
-}

--- a/addon/components/modals-container/prompt.js
+++ b/addon/components/modals-container/prompt.js
@@ -1,8 +1,0 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import PromptModal from 'ember-modals-manager-internal/components/modals-container/prompt';
-import layout from 'ember-modals-manager-internal/templates/components/modals-container/prompt';
-
-export default
-@templateLayout(layout)
-class _PromptModal extends PromptModal {
-}

--- a/app/components/modals-container/alert.js
+++ b/app/components/modals-container/alert.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/alert';

--- a/app/components/modals-container/base.js
+++ b/app/components/modals-container/base.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/base';

--- a/app/components/modals-container/check-confirm.js
+++ b/app/components/modals-container/check-confirm.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/check-confirm';

--- a/app/components/modals-container/confirm.js
+++ b/app/components/modals-container/confirm.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/confirm';

--- a/app/components/modals-container/process.js
+++ b/app/components/modals-container/process.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/process';

--- a/app/components/modals-container/progress.js
+++ b/app/components/modals-container/progress.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/progress';

--- a/app/components/modals-container/prompt-confirm.js
+++ b/app/components/modals-container/prompt-confirm.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/prompt-confirm';

--- a/app/components/modals-container/prompt.js
+++ b/app/components/modals-container/prompt.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-modals-manager/components/modals-container/prompt';


### PR DESCRIPTION
Fixes #12. Non-existant templates were used as layouts.
As the classes themselves were empty and since ember-modals-manager-internal already exports the "parent" component classes they can be removed completely.

The issue described in #12 did not occur in the dummy app and in tests as they were not using the component classes from this addon, but the ones from ember-modals-manager-internal going under the same name (`console.log` from one of the deleted component classes would print from an app using this addon, but not from the demo).

Btw. locally the ember-lts-3.4 and -3.8 ember-try scenarios failed for me, as we miss `ember-fn-helper-polyfill` and `ember-native-class-polyfill`. I don't really get why they pass in travis…